### PR TITLE
Don't provide `run' and keep "test/" out of `load-path'

### DIFF
--- a/test/.nosearch
+++ b/test/.nosearch
@@ -1,0 +1,1 @@
+See `normal-top-level-add-subdirs-to-load-path's doc-string.

--- a/test/run.el
+++ b/test/run.el
@@ -58,5 +58,4 @@
 (when (and noninteractive (simple-paren-runs-this-script-p))
   (simple-paren-run-tests-main))
 
-(provide 'run)
 ;;; run.el ends here


### PR DESCRIPTION
Since you don't `(require 'run)` you also don't have to provide that. I noticed that you provide this feature because another package provides the same.

 It's also a good idea to keep the test directory out of the `load-path`, which is being done using the `.nosearch` file.

I have not run the tests (I was expecting they would be run on travis), so you should to that before merging.