### PR TITLE
keep region active after inserting the first part of a matching pair

### DIFF
--- a/simple-paren.el
+++ b/simple-paren.el
@@ -402,6 +402,7 @@
   (let* ((times (prefix-numeric-value arg))
 	 (beg (ignore-errors (region-beginning)))
 	 (end (and (ignore-errors (region-end)) (copy-marker (region-end))))
+     (deactivate-mark nil)
 	 ;; (face	(or (ignore-errors (eq 'region (get-char-property (1- (point)) 'face)))
 	 ;; 	    (eq 'region (get-char-property (point) 'face))))
 	 fillchar padding)


### PR DESCRIPTION
For example, typing [ on an active region keeps the region active, typing ] deactivate the region.