### PR TITLE
Delete duplicated code

### DIFF
--- a/simple-paren.el
+++ b/simple-paren.el
@@ -310,7 +310,6 @@
 (defun simple-paren--return-complement-char-maybe (erg)
   "For example return \"}\" for \"{\" but keep \"\\\"\"."
   (pcase erg
-    (?‘ ?’)
     (?` ?')
     (?< ?>)
     (?> ?<)
@@ -519,7 +518,6 @@ With numerical ARG 2 honor padding")))
 (simple-paren-define pointing-angle-bracket ?\〈 ?\〉)
 (simple-paren-define pointing-curved-angle-bracket ?\⧼ ?\⧽)
 (simple-paren-define s-shaped-bag-delimiter ?\⟅ ?\⟆)
-(simple-paren-define semicolon ?\; ?\;)
 (simple-paren-define sideways-u-bracket ?\⸦ ?\⸧)
 (simple-paren-define singlequote ?\' ?\')
 (simple-paren-define slash ?\/ ?\/)


### PR DESCRIPTION
This fixes following warnings.

```
In simple-paren--return-complement-char-maybe:
simple-paren.el:312:10: Warning: pcase pattern 8216 shadowed by previous pcase
    pattern

In simple-paren-semicolon:
simple-paren.el:522:2: Warning: function ‘simple-paren-semicolon’ defined
    multiple times in this file
```